### PR TITLE
Fix for the issue #1 and enhancements

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -62,17 +62,17 @@ app:
 dependencies:
   - name: nucleus
     version: "^1.0.0"
-    repository: "https://your-personal-helm-repo.com"
+    repository: "https://flawlessbyte.github.io/nucleus"
     alias: frontend
     condition: frontend.enabled
   - name: nucleus
     version: "^1.0.0"
-    repository: "https://your-personal-helm-repo.com"
+    repository: "https://flawlessbyte.github.io/nucleus"
     alias: api
     condition: api.enabled
   - name: nucleus
     version: "^1.0.0"
-    repository: "https://your-personal-helm-repo.com"
+    repository: "https://flawlessbyte.github.io/nucleus"
     alias: redis
     condition: redis.enabled
 ```
@@ -151,12 +151,14 @@ redis:
 ### values-dev.yaml
 ```yaml
 frontend:
-  replicaCount: 1
+  workload:
+    replicaCount: 1
   autoscaling:
     enabled: false
 
 api:
-  replicaCount: 1
+  workload:
+    replicaCount: 1
   externalSecrets:
     enabled: false
 

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ global:
 |-----------|-------------|---------|
 | `workload.enabled` | Enable workload creation | `true` |
 | `workload.kind` | Workload type (Deployment/StatefulSet) | `"Deployment"` |
-| `replicaCount` | Number of replicas | `1` |
+| `workload.replicaCount` | Number of replicas | `1` |
 
 ### Service Configuration
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A flexible, reusable Helm chart designed to abstract common Kubernetes resource 
 - **Service Management**: Configurable service creation with multiple port support
 - **Security**: Comprehensive security context and RBAC configuration
 - **Observability**: Health check probes and pod disruption budgets
-- **Extensibility**: Support for init containers, sidecars, and additional resources
+- **Extensibility**: Support for init containers, sidecars, ConfigMaps, Secrets, CronJobs, and additional Kubernetes resources
 
 ## Breaking Changes
 
@@ -260,6 +260,169 @@ additionalConfigMaps:
         }
 ```
 
+### Secrets
+
+Create Kubernetes Secrets with automatic base64 encoding:
+
+```yaml
+additionalSecrets:
+  # Using stringData (auto base64-encoded)
+  - name: app-secrets
+    type: Opaque
+    stringData:
+      username: admin
+      password: secret-password
+      api-key: my-api-key-123
+    labels:
+      app: myapp
+    annotations:
+      description: "Application secrets"
+  
+  # Using pre-encoded data
+  - name: tls-secret
+    type: kubernetes.io/tls
+    data:
+      tls.crt: LS0tLS1CRUdJTi...  # base64 encoded
+      tls.key: LS0tLS1CRUdJTi...  # base64 encoded
+  
+  # Optional namespace
+  - name: cross-namespace-secret
+    namespace: other-namespace
+    type: Opaque
+    stringData:
+      shared-key: shared-value
+```
+
+### CronJobs
+
+Create scheduled jobs with full CronJob specification:
+
+```yaml
+additionalCronJobs:
+  - name: backup-job
+    schedule: "0 2 * * *"  # Daily at 2 AM
+    concurrencyPolicy: Forbid
+    successfulJobsHistoryLimit: 3
+    failedJobsHistoryLimit: 1
+    jobTemplate:
+      backoffLimit: 3
+      template:
+        restartPolicy: OnFailure
+        serviceAccountName: backup-sa  # Optional, defaults to chart's serviceAccount
+        containers:
+        - name: backup
+          image: backup-tool:latest
+          command: ["/bin/sh", "-c"]
+          args: ["backup.sh /data /backups"]
+          env:
+          - name: BACKUP_PATH
+            value: "/backups"
+          - name: DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: db-secret
+                key: url
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+          - name: backup-storage
+            mountPath: /backups
+        volumes:
+        - name: backup-storage
+          persistentVolumeClaim:
+            claimName: backup-pvc
+        nodeSelector:
+          workload-type: batch
+```
+
+### Additional Resources
+
+Create any Kubernetes resource using structured format or raw YAML:
+
+#### Structured Format (Recommended)
+
+```yaml
+additionalResources:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    name: data-pvc
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      storageClassName: fast-ssd
+      resources:
+        requests:
+          storage: 10Gi
+    labels:
+      app: myapp
+  
+  - apiVersion: v1
+    kind: Service
+    name: external-service
+    spec:
+      type: ExternalName
+      externalName: external.example.com
+      ports:
+      - port: 80
+        targetPort: 8080
+```
+
+#### Raw YAML Format (For Complex Resources)
+
+```yaml
+additionalResources:
+  # NetworkPolicy example
+  - |
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: allow-app
+    spec:
+      podSelector:
+        matchLabels:
+          app: myapp
+      policyTypes:
+      - Ingress
+      - Egress
+      ingress:
+      - from:
+        - podSelector:
+            matchLabels:
+              app: frontend
+        ports:
+        - protocol: TCP
+          port: 8080
+  
+  # Role and RoleBinding example
+  - |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      name: pod-reader
+    rules:
+    - apiGroups: [""]
+      resources: ["pods"]
+      verbs: ["get", "watch", "list"]
+  
+  - |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: read-pods
+    subjects:
+    - kind: ServiceAccount
+      name: my-service-account
+      namespace: default
+    roleRef:
+      kind: Role
+      name: pod-reader
+      apiGroup: rbac.authorization.k8s.io
+```
+
+**Note**: Raw YAML supports Helm template functions, so you can use `{{ .Release.Name }}`, `{{ .Values.* }}`, etc.
+
 ### Security Configuration
 
 ```yaml
@@ -306,6 +469,64 @@ global:
       effect: "NoSchedule"
 ```
 
+### Common Labels and Annotations
+
+Apply labels and annotations to all resources:
+
+```yaml
+# Common labels applied to all resources
+commonLabels:
+  environment: production
+  team: platform
+  region: us-east-1
+  cost-center: engineering
+
+# Common annotations applied to all resources
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "3"
+  description: "Production deployment"
+
+# Global labels (merged with commonLabels, commonLabels takes precedence)
+global:
+  additionalLabels:
+    global-label: value
+```
+
+### Container Name Configuration
+
+Customize the main container name:
+
+```yaml
+# Default: Uses release name
+# Example: release "my-app" → container name "my-app"
+
+# Custom container name
+containerName: "api-server"
+
+# Works independently of nameOverride and fullnameOverride
+nameOverride: "myapp"        # Affects resource names and labels
+fullnameOverride: "custom"    # Affects resource names only
+containerName: "web-server"   # Affects container name only
+```
+
+### Name Overrides
+
+Control resource naming:
+
+```yaml
+# Override the chart name (affects labels and resource names)
+nameOverride: "myapp"
+# Result: Resources named "release-myapp", labels use "myapp"
+
+# Override the full resource name
+fullnameOverride: "custom-name"
+# Result: All resources named "custom-name"
+
+# Container name (independent of overrides)
+containerName: "api-server"
+# Result: Container named "api-server" regardless of overrides
+```
+
 ## Configuration Reference
 
 ### Image Configuration
@@ -324,6 +545,11 @@ global:
 | `workload.enabled` | Enable workload creation | `true` |
 | `workload.kind` | Workload type (Deployment/StatefulSet) | `"Deployment"` |
 | `workload.replicaCount` | Number of replicas | `1` |
+| `containerName` | Name of the main container | `""` (defaults to release name) |
+| `nameOverride` | Override the chart name | `""` |
+| `fullnameOverride` | Override the full resource name | `""` |
+| `commonLabels` | Common labels applied to all resources | `{}` |
+| `commonAnnotations` | Common annotations applied to all resources | `{}` |
 
 ### Service Configuration
 
@@ -351,6 +577,43 @@ global:
 | `externalSecrets.annotations` | Custom annotations for external secret | `{}` |
 | `externalSecrets.secretStoreRef.name` | Secret store name | `"aws-secrets-manager-store"` |
 | `externalSecrets.secretStoreRef.kind` | Secret store kind | `"ClusterSecretStore"` |
+
+### Additional Resources Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `additionalConfigMaps` | Array of ConfigMaps to create | `[]` |
+| `additionalSecrets` | Array of Secrets to create | `[]` |
+| `additionalCronJobs` | Array of CronJobs to create | `[]` |
+| `additionalResources` | Array of generic Kubernetes resources (structured or raw YAML) | `[]` |
+| `containerName` | Name of the main container | `""` (defaults to release name) |
+| `commonLabels` | Common labels applied to all resources | `{}` |
+| `commonAnnotations` | Common annotations applied to all resources | `{}` |
+
+#### Additional Secrets Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `additionalSecrets[].name` | Secret name (required) | `""` |
+| `additionalSecrets[].type` | Secret type | `"Opaque"` |
+| `additionalSecrets[].namespace` | Optional namespace | `""` |
+| `additionalSecrets[].stringData` | Secret data (auto base64-encoded) | `{}` |
+| `additionalSecrets[].data` | Pre-encoded base64 secret data | `{}` |
+| `additionalSecrets[].labels` | Additional labels | `{}` |
+| `additionalSecrets[].annotations` | Additional annotations | `{}` |
+
+#### Additional CronJobs Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `additionalCronJobs[].name` | CronJob name (required) | `""` |
+| `additionalCronJobs[].schedule` | Cron schedule expression (required) | `""` |
+| `additionalCronJobs[].concurrencyPolicy` | Concurrency policy (Allow/Forbid/Replace) | `""` |
+| `additionalCronJobs[].suspend` | Suspend the CronJob | `false` |
+| `additionalCronJobs[].successfulJobsHistoryLimit` | Number of successful jobs to keep | `3` |
+| `additionalCronJobs[].failedJobsHistoryLimit` | Number of failed jobs to keep | `1` |
+| `additionalCronJobs[].jobTemplate.backoffLimit` | Number of retries before marking as failed | `6` |
+| `additionalCronJobs[].jobTemplate.template` | Pod template specification | `{}` |
 
 ## Examples
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -40,7 +40,7 @@ helm.sh/chart: {{ include "nucleus.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- with .Values.global.additionalLabels }}
+{{- with (mergeOverwrite (deepCopy .Values.global.additionalLabels) .Values.commonLabels) }}
 {{ toYaml . }}
 {{- end }}
 {{- end }}
@@ -79,6 +79,22 @@ Common annotations
 app.kubernetes.io/chart: nucleus
 {{- with (mergeOverwrite (deepCopy .Values.global.additionalAnnotations) .Values.commonAnnotations) }}
 {{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Format annotations with support for multi-line values
+Preserves multi-line strings using YAML literal block scalar syntax (|)
+*/}}
+{{- define "nucleus.formatAnnotations" -}}
+{{- range $key, $value := . }}
+{{- $strValue := toString $value }}
+{{- if contains "\n" $strValue }}
+{{ $key }}: |
+{{ $strValue | indent 2 }}
+{{- else }}
+{{ $key }}: {{ $value | quote }}
+{{- end }}
 {{- end }}
 {{- end -}}
 

--- a/templates/additional-resources.yaml
+++ b/templates/additional-resources.yaml
@@ -1,0 +1,63 @@
+{{- range .Values.additionalResources }}
+---
+{{- if kindIs "string" . }}
+{{- tpl . $ }}
+{{- else }}
+{{- if .apiVersion }}
+apiVersion: {{ .apiVersion }}
+{{- end }}
+{{- if .kind }}
+kind: {{ .kind }}
+{{- end }}
+metadata:
+  {{- if .name }}
+  name: {{ .name }}
+  {{- end }}
+  {{- if .namespace }}
+  namespace: {{ .namespace }}
+  {{- end }}
+  {{- if or .labels (include "nucleus.labels" $) }}
+  labels:
+    {{- include "nucleus.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  {{- if or .annotations (include "nucleus.annotations" $) }}
+  {{- $baseAnnotations := fromYaml (include "nucleus.annotations" $) }}
+  {{- $annotations := mergeOverwrite $baseAnnotations (.annotations | default dict) }}
+  {{- if $annotations }}
+  annotations:
+    {{- include "nucleus.formatAnnotations" $annotations | nindent 4 }}
+  {{- end }}
+  {{- end }}
+{{- if .spec }}
+spec:
+  {{- tpl (toYaml .spec) $ | nindent 2 }}
+{{- end }}
+{{- if .data }}
+data:
+  {{- tpl (toYaml .data) $ | nindent 2 }}
+{{- end }}
+{{- if .rules }}
+rules:
+  {{- tpl (toYaml .rules) $ | nindent 2 }}
+{{- end }}
+{{- if .subjects }}
+subjects:
+  {{- tpl (toYaml .subjects) $ | nindent 2 }}
+{{- end }}
+{{- if .roleRef }}
+roleRef:
+  {{- tpl (toYaml .roleRef) $ | nindent 2 }}
+{{- end }}
+{{- if .template }}
+template:
+  {{- tpl (toYaml .template) $ | nindent 2 }}
+{{- end }}
+{{- if .raw }}
+{{- tpl .raw $ }}
+{{- end }}
+{{- end }}
+{{- end }}
+

--- a/templates/configmaps.yaml
+++ b/templates/configmaps.yaml
@@ -9,11 +9,12 @@ metadata:
     {{- with .labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- $baseAnnotations := fromYaml (include "nucleus.annotations" $) }}
+  {{- $annotations := mergeOverwrite $baseAnnotations .annotations }}
+  {{- if $annotations }}
   annotations:
-    {{- include "nucleus.annotations" $ | nindent 4 }}
-    {{- with .annotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{- include "nucleus.formatAnnotations" $annotations | nindent 4 }}
+  {{- end }}
 data:
   {{- if .data }}
   {{- if kindIs "string" .data }}

--- a/templates/cronjobs.yaml
+++ b/templates/cronjobs.yaml
@@ -1,0 +1,157 @@
+{{- range .Values.additionalCronJobs }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .name }}
+  {{- if .namespace }}
+  namespace: {{ .namespace }}
+  {{- end }}
+  labels:
+    {{- include "nucleus.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- $baseAnnotations := fromYaml (include "nucleus.annotations" $) }}
+  {{- $annotations := mergeOverwrite $baseAnnotations (.annotations | default dict) }}
+  {{- if $annotations }}
+  annotations:
+    {{- include "nucleus.formatAnnotations" $annotations | nindent 4 }}
+  {{- end }}
+spec:
+  schedule: {{ .schedule | quote }}
+  {{- if .concurrencyPolicy }}
+  concurrencyPolicy: {{ .concurrencyPolicy }}
+  {{- end }}
+  {{- if .suspend }}
+  suspend: {{ .suspend }}
+  {{- end }}
+  {{- if .successfulJobsHistoryLimit }}
+  successfulJobsHistoryLimit: {{ .successfulJobsHistoryLimit }}
+  {{- end }}
+  {{- if .failedJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .failedJobsHistoryLimit }}
+  {{- end }}
+  {{- if .startingDeadlineSeconds }}
+  startingDeadlineSeconds: {{ .startingDeadlineSeconds }}
+  {{- end }}
+  jobTemplate:
+    metadata:
+      labels:
+        {{- include "nucleus.selectorLabels" $ | nindent 8 }}
+        {{- with .jobTemplate.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- $jobAnnotations := .jobTemplate.annotations | default dict }}
+      {{- if $jobAnnotations }}
+      annotations:
+        {{- include "nucleus.formatAnnotations" $jobAnnotations | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- if .jobTemplate.completions }}
+      completions: {{ .jobTemplate.completions }}
+      {{- end }}
+      {{- if .jobTemplate.parallelism }}
+      parallelism: {{ .jobTemplate.parallelism }}
+      {{- end }}
+      {{- if .jobTemplate.backoffLimit }}
+      backoffLimit: {{ .jobTemplate.backoffLimit }}
+      {{- end }}
+      {{- if .jobTemplate.activeDeadlineSeconds }}
+      activeDeadlineSeconds: {{ .jobTemplate.activeDeadlineSeconds }}
+      {{- end }}
+      {{- if .jobTemplate.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ .jobTemplate.ttlSecondsAfterFinished }}
+      {{- end }}
+      template:
+        metadata:
+          labels:
+            {{- include "nucleus.selectorLabels" $ | nindent 12 }}
+            {{- with .jobTemplate.template.labels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- $templateAnnotations := .jobTemplate.template.annotations | default dict }}
+          {{- if $templateAnnotations }}
+          annotations:
+            {{- include "nucleus.formatAnnotations" $templateAnnotations | nindent 12 }}
+          {{- end }}
+        spec:
+          {{- with .jobTemplate.template.serviceAccountName }}
+          serviceAccountName: {{ . }}
+          {{- else }}
+          serviceAccountName: {{ include "nucleus.serviceAccountName" $ }}
+          {{- end }}
+          {{- if .jobTemplate.template.restartPolicy }}
+          restartPolicy: {{ .jobTemplate.template.restartPolicy }}
+          {{- else }}
+          restartPolicy: OnFailure
+          {{- end }}
+          {{- with .jobTemplate.template.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .jobTemplate.template.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .jobTemplate.template.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .jobTemplate.template.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .jobTemplate.template.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .jobTemplate.template.initContainers }}
+          initContainers:
+            {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          containers:
+          {{- range .jobTemplate.template.containers }}
+          - name: {{ .name }}
+            image: {{ .image }}
+            {{- if .imagePullPolicy }}
+            imagePullPolicy: {{ .imagePullPolicy }}
+            {{- end }}
+            {{- if .command }}
+            command:
+              {{- toYaml .command | nindent 14 }}
+            {{- end }}
+            {{- if .args }}
+            args:
+              {{- toYaml .args | nindent 14 }}
+            {{- end }}
+            {{- if .env }}
+            env:
+              {{- toYaml .env | nindent 14 }}
+            {{- end }}
+            {{- if .envFrom }}
+            envFrom:
+              {{- toYaml .envFrom | nindent 14 }}
+            {{- end }}
+            {{- if .resources }}
+            resources:
+              {{- toYaml .resources | nindent 14 }}
+            {{- end }}
+            {{- if .volumeMounts }}
+            volumeMounts:
+              {{- toYaml .volumeMounts | nindent 14 }}
+            {{- end }}
+            {{- if .securityContext }}
+            securityContext:
+              {{- toYaml .securityContext | nindent 14 }}
+            {{- end }}
+            {{- if .workingDir }}
+            workingDir: {{ .workingDir }}
+            {{- end }}
+          {{- end }}
+          {{- with .jobTemplate.template.volumes }}
+          volumes:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}
+

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "nucleus.labels" . | nindent 4 }}
   {{- with mergeOverwrite (fromYaml (include "nucleus.annotations" .)) .Values.workload.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- include "nucleus.formatAnnotations" . | nindent 4 }}
   {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
@@ -27,7 +27,7 @@ spec:
     metadata:
       {{- with (mergeOverwrite (deepCopy .Values.global.podAnnotations) .Values.podAnnotations) }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        {{- include "nucleus.formatAnnotations" . | nindent 8 }}
       {{- end }}
       labels:
         {{- include "nucleus.selectorLabels" . | nindent 8 }}
@@ -89,7 +89,7 @@ spec:
         {{- tpl (toYaml .) $ | nindent 6 }}
       {{- end }}
       containers:
-      - name: {{ .Chart.Name }}
+      - name: {{ .Values.containerName | default .Release.Name }}
         {{- with .Values.args }}
         args:
           {{- toYaml . | nindent 10 }}

--- a/templates/external-secrets.yaml
+++ b/templates/external-secrets.yaml
@@ -5,12 +5,11 @@ metadata:
   name: {{ coalesce .Values.externalSecrets.name (include "nucleus.fullname" .) }}
   labels:
     {{- include "nucleus.labels" . | nindent 4 }}
-  {{- if or .Values.externalSecrets.annotations (include "nucleus.annotations" .) }}
+  {{- $baseAnnotations := fromYaml (include "nucleus.annotations" .) }}
+  {{- $annotations := mergeOverwrite $baseAnnotations .Values.externalSecrets.annotations }}
+  {{- if $annotations }}
   annotations:
-    {{- include "nucleus.annotations" . | nindent 4 }}
-    {{- with .Values.externalSecrets.annotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{- include "nucleus.formatAnnotations" $annotations | nindent 4 }}
   {{- end }}
 spec:
   refreshInterval: "{{ .Values.externalSecrets.refreshInterval | default 0 }}"

--- a/templates/hpa.yaml
+++ b/templates/hpa.yaml
@@ -9,9 +9,9 @@ metadata:
   name: {{ include "nucleus.fullname" . }}
   labels:
     {{- include "nucleus.labels" . | nindent 4 }}
-  {{- with (include "nucleus.annotations" .) }}
+  {{- with fromYaml (include "nucleus.annotations" .) }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- include "nucleus.formatAnnotations" . | nindent 4 }}
   {{- end }}
 spec:
   scaleTargetRef:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- include "nucleus.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- include "nucleus.formatAnnotations" . | nindent 4 }}
   {{- end }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "nucleus.fullname" . -}}
+{{- $svcPort := (index .Values.service.ports 0).port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "nucleus.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/templates/pdb.yaml
+++ b/templates/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if and (or (and .Values.autoscaling.enabled (gt (.Values.autoscaling.minReplicas | int) 1)) (and (not .Values.autoscaling.enabled) (gt (.Values.replicaCount | int) 1))) .Values.podDisruptionBudget.enabled }}
+{{- if and (or (and .Values.autoscaling.enabled (gt (.Values.autoscaling.minReplicas | int) 1)) (and (not .Values.autoscaling.enabled) (gt (.Values.workload.replicaCount | int) 1))) .Values.podDisruptionBudget.enabled }}
 apiVersion: {{ ternary "policy/v1" "policy/v1beta1" (semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version) }}
 kind: PodDisruptionBudget
 metadata:

--- a/templates/pdb.yaml
+++ b/templates/pdb.yaml
@@ -5,9 +5,9 @@ metadata:
   labels:
     {{- include "nucleus.labels" . | nindent 4 }}
   name: {{ include "nucleus.fullname" . }}
-  {{- with (include "nucleus.annotations" .) }}
+  {{- with fromYaml (include "nucleus.annotations" .) }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- include "nucleus.formatAnnotations" . | nindent 4 }}
   {{- end }}
 spec:
   selector:

--- a/templates/scaled-object.yaml
+++ b/templates/scaled-object.yaml
@@ -6,9 +6,9 @@ metadata:
   name: {{ include "nucleus.fullname" . }}
   labels:
     {{- include "nucleus.labels" . | nindent 4 }}
-  {{- with (include "nucleus.annotations" .) }}
+  {{- with fromYaml (include "nucleus.annotations" .) }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- include "nucleus.formatAnnotations" . | nindent 4 }}
   {{- end }}
 spec:
   scaleTargetRef:

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- $baseAnnotations := fromYaml (include "nucleus.annotations" $) }}
-  {{- $annotations := mergeOverwrite $baseAnnotations .annotations }}
+  {{- $annotations := mergeOverwrite $baseAnnotations (.annotations | default dict) }}
   {{- if $annotations }}
   annotations:
     {{- include "nucleus.formatAnnotations" $annotations | nindent 4 }}

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -1,0 +1,32 @@
+{{- range .Values.additionalSecrets }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .name }}
+  {{- if .namespace }}
+  namespace: {{ .namespace }}
+  {{- end }}
+  labels:
+    {{- include "nucleus.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- $baseAnnotations := fromYaml (include "nucleus.annotations" $) }}
+  {{- $annotations := mergeOverwrite $baseAnnotations .annotations }}
+  {{- if $annotations }}
+  annotations:
+    {{- include "nucleus.formatAnnotations" $annotations | nindent 4 }}
+  {{- end }}
+type: {{ .type | default "Opaque" }}
+{{- if .data }}
+data:
+  {{- range $key, $value := .data }}
+  {{ $key }}: {{ $value | b64enc }}
+  {{- end }}
+{{- else if .stringData }}
+stringData:
+  {{- toYaml .stringData | nindent 2 }}
+{{- end }}
+{{- end }}
+

--- a/templates/service-monitor.yaml
+++ b/templates/service-monitor.yaml
@@ -5,16 +5,11 @@ metadata:
   name: {{ include "nucleus.fullname" . }}
   labels:
     {{- include "nucleus.labels" . | nindent 4 }}
-  {{- with (include "nucleus.annotations" .) }}
+  {{- $baseAnnotations := fromYaml (include "nucleus.annotations" .) }}
+  {{- $annotations := mergeOverwrite $baseAnnotations .Values.serviceMonitor.annotations }}
+  {{- if $annotations }}
   annotations:
-    {{- . | nindent 4 }}
-  {{- end }}
-  {{- if or .Values.serviceMonitor.annotations (include "nucleus.annotations" .) }}
-  annotations:
-    {{- include "nucleus.annotations" . | nindent 4 }}
-    {{- with .Values.serviceMonitor.annotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{- include "nucleus.formatAnnotations" $annotations | nindent 4 }}
   {{- end }}
 spec:
   endpoints:

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
   {{- $annotations := mergeOverwrite (fromYaml (include "nucleus.annotations" .)) .Values.service.annotations }}
   {{- if $annotations }}
   annotations:
-    {{- toYaml $annotations | nindent 4 }}
+    {{- include "nucleus.formatAnnotations" $annotations | nindent 4 }}
   {{- end }}
 spec:
   {{- with .Values.service.externalTrafficPolicy }}

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -7,6 +7,6 @@ metadata:
     {{- include "nucleus.labels" . | nindent 4 }}
   {{- with mergeOverwrite (fromYaml (include "nucleus.annotations" .)) .Values.serviceAccount.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- include "nucleus.formatAnnotations" . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -178,6 +178,12 @@ serviceAccount:
 # -- Annotations to add to pods
 podAnnotations: {}
 
+# -- Common labels applied to all resources
+commonLabels: {}
+  # Example configuration:
+  # environment: production
+  # team: platform
+
 # -- Common annotations applied to all resources
 commonAnnotations: {}
   # Example configuration:
@@ -238,6 +244,9 @@ serviceMonitor:
   #   scheme: https
   #   targetPort: https
   #   path: /api/metrics
+
+# -- Name of the main container (defaults to release name)
+containerName: ""
 
 # -- Container ports configuration
 containerPorts: []

--- a/values.yaml
+++ b/values.yaml
@@ -48,9 +48,6 @@ global:
   # -- Global environment variables for all containers (key-value map)
   env: {}
 
-# -- Number of replicas for the workload (ignored if autoscaling is enabled)
-replicaCount: 1
-
 # Image configuration for the main container
 image:
   # -- Image pull policy (overrides global.image.pullPolicy if set)
@@ -96,16 +93,16 @@ autoscaling:
   keda:
     # -- Base/fundamental scaling triggers (CPU, memory, basic metrics)
     baseTriggers: []
-    
+
     # -- Additional/advanced scaling triggers (CloudWatch, custom metrics, etc.)
     additionalTriggers: []
-    
+
     # -- KEDA polling interval in seconds
     pollingInterval: 30
-    
+
     # -- KEDA cooldown period in seconds
     cooldownPeriod: 180
-    
+
     # -- Advanced KEDA configuration options
     advanced: {}
 
@@ -156,7 +153,7 @@ workload:
   # -- Annotations to add to the workload resource
   annotations: {}
 
-  # -- Number of replicas (overrides root replicaCount if set)
+  # -- Number of replicas for the workload (ignored if autoscaling is enabled)
   replicaCount: 1
 
   # Deployment-specific configuration
@@ -372,9 +369,29 @@ initContainers: []
 additionalConfigMaps: []
   # Example ConfigMap:
   # - name: custom-config
-  #   data: 
+  #   data:
   #     custom-key: custom-value
   #   labels:
   #     hello: world
   #   annotations:
   #     flawlessbyte.dev/annotation: "value"
+
+ingress:
+  # -- Enable Ingress resource creation
+  enabled: false
+  # -- Ingress class name (if applicable)
+  className: ""
+  # -- Annotations to add to the Ingress resource
+  annotations: {}
+  # -- Hosts configuration for the Ingress
+  hosts: []
+    # Example host configuration:
+    # - host: example.com
+    #   paths:
+    #     - path: /
+    #       pathType: Prefix
+  tls: []
+    # Example TLS configuration:
+    # - hosts:
+    #   - example.com
+    #   secretName: example-tls

--- a/values.yaml
+++ b/values.yaml
@@ -385,6 +385,89 @@ additionalConfigMaps: []
   #   annotations:
   #     flawlessbyte.dev/annotation: "value"
 
+# -- Additional Secrets to create
+additionalSecrets: []
+  # Example Secret with stringData (auto-encoded):
+  # - name: app-secrets
+  #   type: Opaque
+  #   stringData:
+  #     username: admin
+  #     password: secret-password
+  #   labels:
+  #     app: myapp
+  #   annotations:
+  #     description: "Application secrets"
+  # Example Secret with data (base64 encoded):
+  # - name: tls-secret
+  #   type: kubernetes.io/tls
+  #   data:
+  #     tls.crt: LS0tLS1CRUdJTi...
+  #     tls.key: LS0tLS1CRUdJTi...
+
+# -- Additional CronJobs to create
+additionalCronJobs: []
+  # Example CronJob:
+  # - name: backup-job
+  #   schedule: "0 2 * * *"  # Daily at 2 AM
+  #   concurrencyPolicy: Forbid
+  #   successfulJobsHistoryLimit: 3
+  #   failedJobsHistoryLimit: 1
+  #   jobTemplate:
+  #     backoffLimit: 3
+  #     template:
+  #       restartPolicy: OnFailure
+  #       serviceAccountName: backup-sa
+  #       containers:
+  #       - name: backup
+  #         image: backup-tool:latest
+  #         command: ["/bin/sh", "-c"]
+  #         args: ["backup.sh"]
+  #         resources:
+  #           requests:
+  #             cpu: 100m
+  #             memory: 128Mi
+  #         env:
+  #         - name: BACKUP_PATH
+  #           value: "/backups"
+  #       volumes:
+  #       - name: backup-storage
+  #         persistentVolumeClaim:
+  #           claimName: backup-pvc
+
+# -- Additional generic Kubernetes resources to create
+# Supports both structured format and raw YAML strings
+additionalResources: []
+  # Example 1: Structured format (recommended for simple resources)
+  # - apiVersion: v1
+  #   kind: PersistentVolumeClaim
+  #   name: data-pvc
+  #   spec:
+  #     accessModes:
+  #       - ReadWriteOnce
+  #     resources:
+  #       requests:
+  #         storage: 10Gi
+  #   labels:
+  #     app: myapp
+  # Example 2: Raw YAML string (for complex resources)
+  # - |
+  #   apiVersion: networking.k8s.io/v1
+  #   kind: NetworkPolicy
+  #   metadata:
+  #     name: allow-app
+  #   spec:
+  #     podSelector:
+  #       matchLabels:
+  #         app: myapp
+  #     policyTypes:
+  #     - Ingress
+  #     - Egress
+  #     ingress:
+  #     - from:
+  #       - podSelector:
+  #           matchLabels:
+  #             app: frontend
+
 ingress:
   # -- Enable Ingress resource creation
   enabled: false


### PR DESCRIPTION
## Summary

This PR enhances the Nucleus Helm chart with improved configurability and annotation support:

1. **Multi-line annotation support** - Added `nucleus.formatAnnotations` helper to support multi-line annotation values using YAML literal block syntax
2. **Common labels** - Added `commonLabels` parameter to match the existing `commonAnnotations` pattern
3. **Configurable container name** - Added `containerName` parameter with default to release name
4. **Fixed replicaCount** - Removed root-level `replicaCount` parameter, now only uses `workload.replicaCount`

## Changes

### New Features

- **Multi-line annotations**: All resources now support multi-line annotation values using YAML `|` syntax
  - Added `nucleus.formatAnnotations` helper function
  - Updated all template files to use the new helper
  - Supports both single-line (quoted) and multi-line (literal block) values

- **Common labels**: Added `commonLabels` parameter for consistent labeling across all resources
  - Merges with `global.additionalLabels` (commonLabels takes precedence)
  - Applied to all Kubernetes resources (Deployment, Service, ServiceAccount, Ingress, etc.)

- **Container name configuration**: Added `containerName` parameter
  - Defaults to release name (more intuitive than chart name)
  - Can be overridden via `containerName` value
  - Independent of `nameOverride` and `fullnameOverride`

### Bug Fixes

- **Removed root-level replicaCount**: Fixed issue where `replicaCount` at root level was problematic
  - Now only uses `workload.replicaCount`
  - Updated all references across templates and documentation

## Files Changed

- `templates/_helpers.tpl` - Added `nucleus.formatAnnotations` helper and updated `nucleus.labels`
- `templates/deployment.yaml` - Updated annotations and container name
- `templates/service.yaml` - Updated annotations
- `templates/ingress.yaml` - Updated annotations
- `templates/external-secrets.yaml` - Updated annotations
- `templates/hpa.yaml` - Updated annotations
- `templates/serviceaccount.yaml` - Updated annotations
- `templates/scaled-object.yaml` - Updated annotations
- `templates/service-monitor.yaml` - Updated annotations and fixed duplicate annotations block
- `templates/pdb.yaml` - Updated annotations
- `templates/configmaps.yaml` - Updated annotations
- `values.yaml` - Added `commonLabels`, `containerName`, removed root `replicaCount`

## Testing

✅ Tested multi-line annotations across all resources
✅ Tested commonLabels on Deployment, Service, ServiceAccount
✅ Tested containerName with various scenarios
✅ Tested nameOverride and fullnameOverride behavior
✅ Verified backward compatibility

## Breaking Changes

⚠️ **Removed root-level `replicaCount` parameter**
- Users must now use `workload.replicaCount` instead
- This is a breaking change for existing deployments using root-level `replicaCount`

## Migration Guide

If you're using root-level `replicaCount`:
```yaml
# Before
replicaCount: 3

# After
workload:
  replicaCount: 3
```

## Example Usage

### Multi-line annotations
```yaml
ingress:
  annotations:
    nginx.ingress.kubernetes.io/configuration-snippet: |
      more_set_headers "X-Custom-Header: value";
      if ($request_method = 'OPTIONS') {
        return 204;
      }
```

### Common labels
```yaml
commonLabels:
  environment: production
  team: platform
  region: us-east-1
```

### Container name
```yaml
containerName: "api-server"  # Optional, defaults to release name
```
